### PR TITLE
fixing npm test for nodejs v0.12 (test_database.js)

### DIFF
--- a/test/test_database.js
+++ b/test/test_database.js
@@ -26,7 +26,7 @@ exports.test = function(sql, assert, done) {
 
 	// Export the database to an Uint8Array containing the SQLite database file
 	var binaryArray = db.export();
-	assert.strictEqual(String.fromCharCode.apply(null,binaryArray.slice(0,6)), 'SQLite',
+	assert.strictEqual(String.fromCharCode.apply(null,binaryArray.subarray(0,6)), 'SQLite',
 		      "The first 6 bytes of an SQLite database should form the word 'SQLite'");
 	db.close();
 


### PR DESCRIPTION
nodejs v0.12 for some reason doesn't have Uint8Array.prototype.slice.  using Uint8Array.prototype.subarray fixes this.

also note on mdn, subarray is better supported among browsers than slice:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray
vs
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice

```
kaizhu@minime2:~/src/sql.js$ npm test

> sql.js@0.2.21 test /Users/kaizhu/src/sql.js
> node test/all.js

Running all tests:
  test blob
Testing writing BLOBs
    ✓ BLOB read from the database should be the same size as the one that was inserted
    ✓ Reading BLOB
    ✓ Reading BLOB with a null byte
    ✓ stmt.step() should return false after all values were read
  test database
    ✓ Should export a Database object
    ✓ Creating a database object
    ✓ Creating a table should not return anything
    ✓ db.exec() return value
    ⚡ TypeError: undefined is not a function
        at exports.test (/Users/kaizhu/src/sql.js/test/test_database.js:29:64)
        at test (/Users/kaizhu/src/sql.js/node_modules/test/test.js:29:20)
        at next (/Users/kaizhu/src/sql.js/node_modules/test/test.js:69:7)
        at Object.end (/Users/kaizhu/src/sql.js/node_modules/test/test.js:25:7)
        at test (/Users/kaizhu/src/sql.js/node_modules/test/test.js:41:28)
        at next (/Users/kaizhu/src/sql.js/node_modules/test/test.js:69:7)
        at suite (/Users/kaizhu/src/sql.js/node_modules/test/test.js:71:5)
        at Object.run (/Users/kaizhu/src/sql.js/node_modules/test/test.js:87:3)
        at Object.<anonymous> (/Users/kaizhu/src/sql.js/test/all.js:19:45)
        at Module._compile (module.js:460:26)
  test errors
    ✓ Querying an invalid database should throw an error

```