### PR TITLE
Add gh-pages to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 test/
 c/
 coffee/
+gh-pages/
 node_modules/
 node-debug.log
 .git/


### PR DESCRIPTION
At the moment gh-pages makes up over the half of the size of the install size.
This merge request adds it to the `.npmignore` in order to save 15MB.

Closes #197