### PR TITLE
Add support for opening URLs (lazy database file)

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -235,11 +235,15 @@ class Statement
 # Represents an SQLite database
 class Database
     # Open a new database either by creating a new one or opening an existing one,
-    # stored in the byte array passed in first argument
-    # @param data [Array<Integer>] An array of bytes representing an SQLite database file
-    constructor: (data) ->
+    # either stored in the byte array or at the URL passed in first argument
+    # @param dataOrURL [Array<Integer>, String] An array of bytes representing an SQLite database file or the URL to the database file
+    constructor: (dataOrURL) ->
         @filename = 'dbfile_' + (0xffffffff*Math.random()>>>0)
-        if data? then FS.createDataFile '/', @filename, data, true, true
+        if dataOrURL?
+            if typeof dataOrURL is 'string'  # URL
+                FS.createLazyFile '/', @filename, dataOrURL, true, true
+            else  # Data
+                FS.createDataFile '/', @filename, dataOrURL, true, true
         @handleError sqlite3_open @filename, apiTemp
         @db = getValue(apiTemp, 'i32')
         RegisterExtensionFunctions(@db)

--- a/src/worker.coffee
+++ b/src/worker.coffee
@@ -14,7 +14,13 @@ if typeof importScripts is 'function' # Detect webworker context
             switch data?['action']
                 when 'open'
                     buff = data['buffer']
-                    createDb (if buff then new Uint8Array(buff) else undefined)
+                    url = data['url']
+                    if buff
+                        createDb (new Uint8Array(buff))
+                    else if url
+                        createDb url
+                    else
+                        createDb undefined
                     postMessage
                         'id': data['id']
                         'ready': true


### PR DESCRIPTION
I've added support for opening URLs using [`FS.createLazyFile`](https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.createLazyFile) API of Emscripten. I've modified `api.coffee` and `worker.coffee` respectively.

It might be also useful to document somewhere (README or the API docs?) that the following headers must be present for the file to be lazy-loaded:

1. `Accept-Ranges: bytes`
2. `Content-Length`
3. `Content-Encoding` (if other than `identity`)

Care must be taken that these headers are accessible from XHR requests, thus appropriate CORS headers (*e.g.* `Access-Control-Expose-Headers`) must be set accordingly.