### PR TITLE
fix function pointer leak

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -244,6 +244,7 @@ class Database
         @db = getValue(apiTemp, 'i32')
         RegisterExtensionFunctions(@db)
         @statements = {} # A list of all prepared statements of the database
+        @functions = [] # A list of all user function (created by create_function call) of the database
 
     ### Execute an SQL query, ignoring the rows it returns.
 
@@ -395,6 +396,7 @@ class Database
     ###
     'export': ->
         stmt['free']() for _,stmt of @statements
+        removeFunction(func) for func in @functions
         @handleError sqlite3_close_v2 @db
         binaryDb = FS.readFile @filename, encoding:'binary'
         @handleError sqlite3_open @filename, apiTemp
@@ -414,6 +416,7 @@ class Database
     ###
     'close': ->
         stmt['free']() for _,stmt of @statements
+        removeFunction(func) for func in @functions
         @handleError sqlite3_close_v2 @db
         FS.unlink '/' + @filename
         @db = null
@@ -481,5 +484,6 @@ class Database
 
         # Generate a pointer to the wrapped, user defined function, and register with SQLite.
         func_ptr = addFunction(wrapped_func)
+        @functions.push(func_ptr);
         @handleError sqlite3_create_function_v2 @db, name, func.length, SQLite.UTF8, 0, func_ptr, 0, 0, 0
         return @

--- a/test/test_functions_recreate.js
+++ b/test/test_functions_recreate.js
@@ -1,7 +1,9 @@
 exports.test = function(sql, assert) {
   // Test 1: Create a database, Register single function, close database, repeat 1000 times
+  
   for (var i = 1; i <= 1000; i++) 
   {
+    let lastStep=(i==1000);
     let db = new sql.Database();
     function add() {return i;}
     try
@@ -14,15 +16,17 @@ exports.test = function(sql, assert) {
     }
     var result = db.exec("SELECT TestFunction"+i+"()");
     var result_str = result[0]["values"][0][0];
-    assert.equal(result_str, i, "Test 1: Recreate database "+i+"th times and register function");
+    if((result_str!=i)||(lastStep))
+      assert.equal(result_str, i, "Test 1: Recreate database "+i+"th times and register function");
     db.close();
   }
   
-  // Test 2: Create a database, Register same function  1000 times, close database, repeat
+  // Test 2: Create a database, Register same function  1000 times, close database
   {
     let db = new sql.Database();
     for (var i = 1; i <= 1000; i++) 
     {
+      let lastStep=(i==1000);
       function add() {return i;}
       try
       {
@@ -34,7 +38,8 @@ exports.test = function(sql, assert) {
       }
       var result = db.exec("SELECT TestFunction()");
       var result_str = result[0]["values"][0][0];
-      assert.equal(result_str, i, "Test 2: Reregister function "+i+"th times");
+      if((result_str!=i)||(lastStep))
+        assert.equal(result_str, i, "Test 2: Reregister function "+i+"th times");
     }
     db.close();
   }
@@ -46,7 +51,7 @@ if (module == require.main) {
   const sql_loader = require('./load_sql_lib');
   sql_loader(target_file).then((sql)=>{
     require('test').run({
-      'test functions recreeate': function(assert){
+      'test creating multiple functions': function(assert){
         exports.test(sql, assert);
       }
     });

--- a/test/test_functions_recreate.js
+++ b/test/test_functions_recreate.js
@@ -12,12 +12,17 @@ exports.test = function(sql, assert) {
     }catch(e)
     {
       assert.ok(false,"Test 1: Recreate database "+i+"th times and register function failed with exception:"+e);
+      db.close();
       break;
     }
     var result = db.exec("SELECT TestFunction"+i+"()");
     var result_str = result[0]["values"][0][0];
-    if((result_str!=i)||(lastStep))
+    if((result_str!=i)||lastStep)
+    {
       assert.equal(result_str, i, "Test 1: Recreate database "+i+"th times and register function");
+      db.close();
+      break;
+    }
     db.close();
   }
   
@@ -38,8 +43,11 @@ exports.test = function(sql, assert) {
       }
       var result = db.exec("SELECT TestFunction()");
       var result_str = result[0]["values"][0][0];
-      if((result_str!=i)||(lastStep))
+      if((result_str!=i)||lastStep)
+      {
         assert.equal(result_str, i, "Test 2: Reregister function "+i+"th times");
+        break;
+      }
     }
     db.close();
   }

--- a/test/test_functions_recreate.js
+++ b/test/test_functions_recreate.js
@@ -1,0 +1,58 @@
+exports.test = function(sql, assert) {
+  // Test 1: Create a database, Register single function, close database, repeat 1000 times
+  for (var i = 1; i <= 1000; i++) 
+  {
+    let db = new sql.Database();
+    function add() {return i;}
+    try
+    {
+      db.create_function("TestFunction"+i, add)
+    }catch(e)
+    {
+      assert.ok(false,"Test 1: Recreate database "+i+"th times and register function failed with exception:"+e);
+      break;
+    }
+    var result = db.exec("SELECT TestFunction"+i+"()");
+    var result_str = result[0]["values"][0][0];
+    assert.equal(result_str, i, "Test 1: Recreate database "+i+"th times and register function");
+    db.close();
+  }
+  
+  // Test 2: Create a database, Register same function  1000 times, close database, repeat
+  {
+    let db = new sql.Database();
+    for (var i = 1; i <= 1000; i++) 
+    {
+      function add() {return i;}
+      try
+      {
+        db.create_function("TestFunction", add);
+      }catch(e)
+      {
+        assert.ok(false,"Test 2: Reregister function "+i+"th times failed with exception:"+e);
+        break;
+      }
+      var result = db.exec("SELECT TestFunction()");
+      var result_str = result[0]["values"][0][0];
+      assert.equal(result_str, i, "Test 2: Reregister function "+i+"th times");
+    }
+    db.close();
+  }
+};
+
+
+if (module == require.main) {
+	const target_file = process.argv[2];
+  const sql_loader = require('./load_sql_lib');
+  sql_loader(target_file).then((sql)=>{
+    require('test').run({
+      'test functions recreeate': function(assert){
+        exports.test(sql, assert);
+      }
+    });
+  })
+  .catch((e)=>{
+    console.error(e);
+    assert.fail(e);
+  });
+}


### PR DESCRIPTION
Function pointers, allocated in db.create_function, was not released on connection close.
And after 64 cycles of opening, adding function and closing db, create_function used to throw exception 
"Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS"
