### PR TITLE
Fix data type conversion in user-defined functions

### DIFF
--- a/src/exported_functions.json
+++ b/src/exported_functions.json
@@ -34,5 +34,9 @@
 "_sqlite3_result_double",
 "_sqlite3_result_null",
 "_sqlite3_result_text",
+"_sqlite3_result_blob",
+"_sqlite3_result_int",
+"_sqlite3_result_int64",
+"_sqlite3_result_error",
 "_RegisterExtensionFunctions"
 ]

--- a/src/exports.coffee
+++ b/src/exports.coffee
@@ -53,6 +53,10 @@ sqlite3_value_double = Module['cwrap'] 'sqlite3_value_double', 'number', ['numbe
 sqlite3_result_double = Module['cwrap'] 'sqlite3_result_double', '', ['number', 'number']
 sqlite3_result_null = Module['cwrap'] 'sqlite3_result_null', '', ['number']
 sqlite3_result_text = Module['cwrap'] 'sqlite3_result_text', '', ['number', 'string', 'number', 'number']
+sqlite3_result_blob = Module['cwrap'] 'sqlite3_result_blob', '', ['number', 'number', 'number', 'number']
+sqlite3_result_int = Module['cwrap'] 'sqlite3_result_int', '', ['number','number']
+sqlite3_result_int64 = Module['cwrap'] 'sqlite3_result_int64', '', ['number', 'number']
+sqlite3_result_error = Module['cwrap'] 'sqlite3_result_error', '', ['number', 'string', 'number']
 RegisterExtensionFunctions = Module['cwrap'] 'RegisterExtensionFunctions', 'number', ['number']
 
 # Export the API


### PR DESCRIPTION
Fixed type conversion in user-defined functions:
1) false, zero, empty sting was returned as null (by "if not result")
2) int64 was revived as int32 (by sqlite3_value_int)
3) booleans returned as double (should be int)
4) add blob support
5) add passing error to sqlite in case of exception in user function (sqlite3_result_error)
6) add check for unknown type in return value
User-defined functions type conversion now same as in bindValue.
+Tests