### PR TITLE
some build updates & fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ sqlite-src/$(SQLITE_AMALGAMATION)/$(EXTENSION_FUNCTIONS): cache/$(EXTENSION_FUNC
 
 .PHONY: clean 
 clean: 
-	rm -rf out/* dist/*	
+	rm -rf out/* dist/*
 
 .PHONY: clean-all
 clean-all: 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,14 @@ EXTENSION_FUNCTIONS_SHA1 = c68fa706d6d9ff98608044c00212473f9c14892f
 
 EMCC=emcc
 
-CFLAGS=-O2 -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DISABLE_LFS -DLONGDOUBLE_TYPE=double -DSQLITE_THREADSAFE=0 -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS
+CFLAGS = \
+	-O2 \
+	-DLONGDOUBLE_TYPE=double \
+	-DSQLITE_OMIT_LOAD_EXTENSION \
+	-DSQLITE_DISABLE_LFS \
+	-DSQLITE_ENABLE_FTS3 \
+	-DSQLITE_ENABLE_FTS3_PARENTHESIS \
+	-DSQLITE_THREADSAFE=0
 
 # When compiling to WASM, enabling memory-growth is not expected to make much of an impact, so we enable it for all builds
 # Since tihs is a library and not a standalone executable, we don't want to catch unhandled Node process exceptions

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SQLITE_AMALGAMATION = sqlite-amalgamation-3300100
 SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip
 SQLITE_AMALGAMATION_ZIP_SHA1 = ff9b4e140fe0764bc7bc802facf5ac164443f517
 
-# Note that extension-functions.c hasn't been updated since 2010-02-06, so likely doesn't need to be updated 
+# Note that extension-functions.c hasn't been updated since 2010-02-06, so likely doesn't need to be updated
 EXTENSION_FUNCTIONS = extension-functions.c
 EXTENSION_FUNCTIONS_URL = https://www.sqlite.org/contrib/download/extension-functions.c?get=25
 EXTENSION_FUNCTIONS_SHA1 = c68fa706d6d9ff98608044c00212473f9c14892f
@@ -32,7 +32,7 @@ EMFLAGS = \
 
 EMFLAGS_WASM = \
 	-s WASM=1 \
-	-s ALLOW_MEMORY_GROWTH=1 
+	-s ALLOW_MEMORY_GROWTH=1
 
 EMFLAGS_OPTIMIZED= \
 	-s INLINING_LIMIT=50 \
@@ -67,19 +67,19 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/
 .PHONY: optimized
 optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
 
-dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/exported_functions.json src/exported_runtime_methods.json 
+dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/exported_functions.json src/exported_runtime_methods.json
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) -s WASM=0 $(BITCODE_FILES) --pre-js out/api.js -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
-dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/exported_functions.json src/exported_runtime_methods.json 
+dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/exported_functions.json src/exported_runtime_methods.json
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) --pre-js out/api.js -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
-dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/exported_functions.json src/exported_runtime_methods.json 
+dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.js src/exported_functions.json src/exported_runtime_methods.json
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) -s WASM=0 -s ALLOW_MEMORY_GROWTH=1 $(BITCODE_FILES) --pre-js out/api.js -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
@@ -180,12 +180,12 @@ sqlite-src/$(SQLITE_AMALGAMATION)/$(EXTENSION_FUNCTIONS): cache/$(EXTENSION_FUNC
 	cp 'cache/$(EXTENSION_FUNCTIONS)' $@
 
 
-.PHONY: clean 
-clean: 
+.PHONY: clean
+clean:
 	rm -rf out/* dist/*
 
 .PHONY: clean-all
-clean-all: 
+clean-all:
 	rm -f out/* dist/* cache/*
 	rm -rf sqlite-src/
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) out/api.
 worker: dist/worker.sql-asm.js dist/worker.sql-asm-debug.js dist/worker.sql-wasm.js dist/worker.sql-wasm-debug.js
 
 out/worker.js: src/worker.coffee
-	cat $^ | coffee --bare --compile --stdio > $@
+	cat $^ | npx coffee --bare --compile --stdio > $@
 
 dist/worker.sql-asm.js: dist/sql-asm.js out/worker.js
 	cat $^ > $@
@@ -125,7 +125,7 @@ dist/worker.sql-wasm-debug.js: dist/sql-wasm-debug.js out/worker.js
 
 out/api.js: src/output-pre.js src/api.coffee src/exports.coffee src/api-data.coffee src/output-post.js
 	mkdir -p out
-	cat src/api.coffee src/exports.coffee src/api-data.coffee | coffee --bare --compile --stdio > $@
+	cat src/api.coffee src/exports.coffee src/api-data.coffee | npx coffee --bare --compile --stdio > $@
 	cat src/output-pre.js $@ src/output-post.js > out/api-wrapped.js
 	mv out/api-wrapped.js $@
 


### PR DESCRIPTION
- remove trailing tab from `Makefile`
- remove trailing spaces from `Makefile`
- use `npx` to run local coffeescript in `Makefile`
- split up & sort `CFLAGS` in Makefile - should make it a little easier for those who may need to customize the build settings in `CFLAGS`

I would be happy to split these proposed changes into individual PRs.