### PR TITLE
some more build updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
-
 # Web worker API
 .PHONY: worker
 worker: dist/worker.sql-asm.js dist/worker.sql-asm-debug.js dist/worker.sql-wasm.js dist/worker.sql-wasm-debug.js

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ EXPORTED_METHODS_JSON_FILES = src/exported_functions.json src/exported_runtime_m
 all: optimized debug worker
 
 .PHONY: debug
-debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
+debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js dist/sql-asm-memory-growth-debug.js
 
 dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -82,6 +82,12 @@ dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FIL
 
 dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	mv $@ out/tmp-raw.js
+	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
+	rm out/tmp-raw.js
+
+dist/sql-asm-memory-growth-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js


### PR DESCRIPTION
Most important:

- use more constants - should help support some custom builds

less important - _updated_:

- ~~simplify wrapping of dist/*.js~~
- _remove an extra blank line_
- add __`dist/sql-asm-memory-growth-debug.js`__ build target

The proposed __`dist/sql-asm-memory-growth-debug.js`__ build target would also help me support a custom build for a major customer. I will completely understand if this proposed build target is not wanted.

I would also be happy to split some of these changes out if needed.