### PR TITLE
cleanup: line spacing fixes in local server script

### DIFF
--- a/examples/start_local_server.py
+++ b/examples/start_local_server.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
+
 import BaseHTTPServer, SimpleHTTPServer, os
- 
+
 # We need to host from the root because we are going to be requesting files inside of dist
 os.chdir('../')
 port=8081
 print "Running on port %d" % port
- 
+
 SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
 
 httpd = BaseHTTPServer.HTTPServer(('localhost', port), SimpleHTTPServer.SimpleHTTPRequestHandler)
- 
+
 print "Mapping \".wasm\" to \"%s\"" % SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map['.wasm']
 httpd.serve_forever()


### PR DESCRIPTION
in `examples/start_local_server.py`:

- newline after the shebang
- remove trailing whitespace
- newline at the end of the file