### PR TITLE
SQLite 3.31.1 update in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@
 
 # I got this handy makefile syntax from : https://github.com/mandel59/sqlite-wasm (MIT License) Credited in LICENSE
 # To use another version of Sqlite, visit https://www.sqlite.org/download.html and copy the appropriate values here:
-SQLITE_AMALGAMATION = sqlite-amalgamation-3300100
-SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip
-SQLITE_AMALGAMATION_ZIP_SHA1 = ff9b4e140fe0764bc7bc802facf5ac164443f517
+SQLITE_AMALGAMATION = sqlite-amalgamation-3310100
+SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip
+SQLITE_AMALGAMATION_ZIP_SHA1 = a58e91a39b7b4ab720dbc843c201fb6a18eaf32b
 
 # Note that extension-functions.c hasn't been updated since 2010-02-06, so likely doesn't need to be updated
 EXTENSION_FUNCTIONS = extension-functions.c


### PR DESCRIPTION
as requested in #338

I did check that super-long double values are not broken by this update if we remove `-DLONGDOUBLE_TYPE=double` from `Makefile` as I proposed in PR #337.

TODO:

- [ ] rebuild `dist` artifacts if this PR is merged